### PR TITLE
Add TWZRD Agent Intel — Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A curated list of awesome GPTs
 - [Education](#education)
 - [For Developers](#for-developers)
 - [For Fun](#for-fun)
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** - Solana-native x402 MCP server for AI agent trust scoring. Free tools: `score_agent(wallet)`, `preflight_check(wallet)`. Paid: `get_trust_receipt` via HTTP 402 + USDC on Solana. MCP: `https://intel.twzrd.xyz/mcp`
 - [Lifestyle](#lifestyle)
 - [Productivity](#productivity)
 - [Writing](#writing)


### PR DESCRIPTION
## Summary

Adds **[TWZRD Agent Intel](https://intel.twzrd.xyz)** — a Solana-native x402 trust scoring MCP server for AI agents.

- **MCP endpoint**: streamable-HTTP at `https://intel.twzrd.xyz/mcp` (zero install, no npm)
- **Free tools**: `score_agent(wallet)`, `preflight_check(wallet)` — Solana wallet trust scores
- **Paid tool**: `get_trust_receipt(wallet)` — signed trust receipt via HTTP 402 + USDC micropayment on Solana
- **Config**: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`